### PR TITLE
feat: Update documentation for bolt world program to use the higher level API

### DIFF
--- a/BOLT/getting_started/world_program.mdx
+++ b/BOLT/getting_started/world_program.mdx
@@ -26,16 +26,19 @@ Initiating a project with bolt init automatically generates a simple usage examp
 Create a new world instance as demonstrated below:
 
 ```typescript
+const registryPda = FindWorldRegistryPda();
 const registry = await Registry.fromAccountAddress(
   provider.connection,
   registryPda
 );
+
 const worldId = new anchor.BN(registry.worlds);
-const worldPda = FindWorldPda(new anchor.BN(worldId));
+const worldPda = FindWorldPda(worldId);
+
 const initializeWorldIx = createInitializeNewWorldInstruction({
-  world: worldPda,
-  registry: registryPda,
   payer: provider.wallet.publicKey,
+  registry: registryPda,
+  world: worldPda,
 });
 
 const tx = new anchor.web3.Transaction().add(initializeWorldIx);
@@ -48,14 +51,16 @@ To add a new entity:
 
 ```typescript
 const world = await World.fromAccountAddress(provider.connection, worldPda);
+
 const entityId = new anchor.BN(world.entities);
-entityPda = FindEntityPda(worldId, entityId);
+const entityPda = FindEntityPda(worldId, entityId);
 
 let createEntityIx = createAddEntityInstruction({
-  world: worldPda,
   payer: provider.wallet.publicKey,
+  world: worldPda,
   entity: entityPda,
 });
+
 const tx = new anchor.web3.Transaction().add(createEntityIx);
 await provider.sendAndConfirm(tx);
 ```
@@ -68,15 +73,17 @@ For attaching components:
 const positionComponentPda = FindComponentPda(
   positionComponent.programId,
   entityPda,
-  ""
+  "origin" // If an entity has multiple position component, we want to differenciate
 );
-let initComponentIx = createInitializeComponentInstruction({
+
+let inititializeComponentIx = createInitializeComponentInstruction({
   payer: provider.wallet.publicKey,
   entity: entityPda,
   data: positionComponentPda,
   componentProgram: positionComponent.programId,
 });
-const tx = new anchor.web3.Transaction().add(initComponentIx);
+
+const tx = new anchor.web3.Transaction().add(inititializeComponentIx);
 await provider.sendAndConfirm(tx);
 ```
 
@@ -85,11 +92,15 @@ await provider.sendAndConfirm(tx);
 To apply a system:
 
 ```typescript
-let applySystemIx = createApplyInstruction({
-  componentProgram: positionComponent.programId,
+let applySystemIx = createApplySystemInstruction({
+  authority: provider.wallet.publicKey,
   boltSystem: systemMovement.programId,
-  boltComponent: positionComponentPda,
+  entity: entityPda,
+  componentProgram: positionComponent.programId,
+
+  boltComponent: positionComponentPda, // TODO - how to do this properly?
 });
+
 const tx = new anchor.web3.Transaction().add(applySystemIx);
 await provider.sendAndConfirm(tx);
 ```

--- a/BOLT/getting_started/world_program.mdx
+++ b/BOLT/getting_started/world_program.mdx
@@ -61,7 +61,6 @@ const inititializeComponent = await InitializeComponent({
 const signature = await provider.sendAndConfirm(
   inititializeComponent.transaction
 );
-const componentPda = transaction.componentPda; // we can use this later
 ```
 
 ## Applying Systems

--- a/BOLT/getting_started/world_program.mdx
+++ b/BOLT/getting_started/world_program.mdx
@@ -57,7 +57,6 @@ const inititializeComponent = await InitializeComponent({
   payer: provider.wallet.publicKey,
   entity: entityPda,
   componentId: positionComponent.programId,
-  seed: "my_id", // In case an entity has multiple of the same component, we differenciate
 });
 const signature = await provider.sendAndConfirm(
   inititializeComponent.transaction
@@ -75,7 +74,6 @@ const applySystem = await ApplySystem({
   system: systemMovement.programId,
   entity: entityPda,
   components: [positionComponent.programId],
-  seeds: ["my_id"],
 });
 const signature = await provider.sendAndConfirm(applySystem.transaction);
 ```

--- a/BOLT/getting_started/world_program.mdx
+++ b/BOLT/getting_started/world_program.mdx
@@ -26,23 +26,12 @@ Initiating a project with bolt init automatically generates a simple usage examp
 Create a new world instance as demonstrated below:
 
 ```typescript
-const registryPda = FindWorldRegistryPda();
-const registry = await Registry.fromAccountAddress(
-  provider.connection,
-  registryPda
-);
-
-const worldId = new anchor.BN(registry.worlds);
-const worldPda = FindWorldPda(worldId);
-
-const initializeWorldIx = createInitializeNewWorldInstruction({
+const initializeNewWorld = await InitializeNewWorld({
   payer: provider.wallet.publicKey,
-  registry: registryPda,
-  world: worldPda,
+  connection: provider.connection,
 });
-
-const tx = new anchor.web3.Transaction().add(initializeWorldIx);
-const txSign = await provider.sendAndConfirm(tx);
+const signature = await provider.sendAndConfirm(initializeNewWorld.transaction);
+const worldPda = initializeNewWorld.worldPda; // we can use this later
 ```
 
 ## Adding a New Entity
@@ -50,19 +39,13 @@ const txSign = await provider.sendAndConfirm(tx);
 To add a new entity:
 
 ```typescript
-const world = await World.fromAccountAddress(provider.connection, worldPda);
-
-const entityId = new anchor.BN(world.entities);
-const entityPda = FindEntityPda(worldId, entityId);
-
-let createEntityIx = createAddEntityInstruction({
+const addEntity = await AddEntity({
   payer: provider.wallet.publicKey,
   world: worldPda,
-  entity: entityPda,
+  connection: provider.connection,
 });
-
-const tx = new anchor.web3.Transaction().add(createEntityIx);
-await provider.sendAndConfirm(tx);
+const signature = await provider.sendAndConfirm(addEntity.transaction);
+const entityPda = addEntity.entityPda; // we can use this later
 ```
 
 ## Attaching Components to an Entity
@@ -70,21 +53,16 @@ await provider.sendAndConfirm(tx);
 For attaching components:
 
 ```typescript
-const positionComponentPda = FindComponentPda(
-  positionComponent.programId,
-  entityPda,
-  "origin" // If an entity has multiple position component, we want to differenciate
-);
-
-let inititializeComponentIx = createInitializeComponentInstruction({
+const inititializeComponent = await InitializeComponent({
   payer: provider.wallet.publicKey,
   entity: entityPda,
-  data: positionComponentPda,
-  componentProgram: positionComponent.programId,
+  componentId: positionComponent.programId,
+  seed: "my_id", // In case an entity has multiple of the same component, we differenciate
 });
-
-const tx = new anchor.web3.Transaction().add(inititializeComponentIx);
-await provider.sendAndConfirm(tx);
+const signature = await provider.sendAndConfirm(
+  inititializeComponent.transaction
+);
+const componentPda = transaction.componentPda; // we can use this later
 ```
 
 ## Applying Systems
@@ -92,15 +70,12 @@ await provider.sendAndConfirm(tx);
 To apply a system:
 
 ```typescript
-let applySystemIx = createApplySystemInstruction({
+const applySystem = await ApplySystem({
   authority: provider.wallet.publicKey,
-  boltSystem: systemMovement.programId,
+  system: systemMovement.programId,
   entity: entityPda,
-  componentProgram: positionComponent.programId,
-
-  boltComponent: positionComponentPda, // TODO - how to do this properly?
+  components: [positionComponent.programId],
+  seeds: ["my_id"],
 });
-
-const tx = new anchor.web3.Transaction().add(applySystemIx);
-await provider.sendAndConfirm(tx);
+const signature = await provider.sendAndConfirm(applySystem.transaction);
 ```


### PR DESCRIPTION
# Summary

The documentation is still using the first version of the API generated by solita directly.
We update it to use a more high-level api provided by typescript bolt-sdk.

# Details

- use `InitializeNewWorld` instead of `createInitializeNewWorldInstruction`
- use `AddEntity` instead of `createAddEntityInstruction`
- use `InitializeComponent` instead of `createInitializeComponentInstruction`
- use `ApplySystem` instead of `createApplySystemInstruction`

# Notes

N/A