### PR TITLE
feat: github workflow to validate PR title

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+> ⚠️ NOTE: Use notes like this to emphasize something important about the PR.
+>
+> This could include other PRs this PR is built on top of; API breaking changes; reasons for why the PR is on hold; or anything else you would like to draw attention to.
+
+|   Status   |                Type                 | ⚠️ Core Change |           Issue           |
+| :--------: | :---------------------------------: | :------------: | :-----------------------: |
+| Ready/Hold | Feature/Bug/Tooling/Refactor/Hotfix |     Yes/No     | [Link](<Issue link here>) |
+
+## Problem
+
+_What problem are you trying to solve?_
+
+## Solution
+
+_How did you solve the problem?_
+
+## Before & After Screenshots
+
+_Insert screenshots of example code output_
+
+**BEFORE**:
+[insert screenshot here]
+
+**AFTER**:
+[insert screenshot here]
+
+## Other changes (e.g. bug fixes, small refactors)
+
+## Deploy Notes
+
+_Notes regarding deployment of the contained body of work. These should note any
+new dependencies, new scripts, etc._
+
+**New scripts**:
+
+- `script` : script details
+
+**New dependencies**:
+
+- `dependency` : dependency details

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,26 @@
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  validate-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Validate PR title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_TITLE=$(jq -r .pull_request.title < $GITHUB_EVENT_PATH)
+          echo "PR Title: $PR_TITLE"
+
+          if [[ ! $PR_TITLE =~ ^(feat|fix|docs|style|refactor|test|chore)\: ]]; then
+            echo "Invalid PR title. It must start with one of the following: feat, fix, docs, style, refactor, test, chore."
+            exit 1
+          else
+            echo "PR title is valid."
+          fi


### PR DESCRIPTION
Because

- there is no GitHub CI workflow to validate PR


This commit

- CI workflow to validate PR

cc - @GabrielePicco , @crypto-vincent 
