### PR TITLE
[docs] Session Keys - integrating-sessions-in-your-program.mdx 

### DIFF
--- a/Build/Session Keys/integrating-sessions-in-your-program.mdx
+++ b/Build/Session Keys/integrating-sessions-in-your-program.mdx
@@ -3,55 +3,257 @@ title: "Integrating Sessions in your Program"
 description: "Integrate and manage sessions in your Solana Programs"
 ---
 
-This is a guide on how you can integrate Session Keys into your Solana Anchor programs.
+This guide demonstrates how to integrate Session Keys into your Solana Anchor programs, using a simple counter program as an example.
 
 ## Installation
 
-```rust
+First, add the session-keys crate to your Cargo.toml:
+
+```toml
+[dependencies]
+session-keys = { version = "1.0.0", features = ["no-entrypoint"] }
+```
+
+Or use the cargo command:
+
+```bash
 cargo add session-keys --features no-entrypoint
 ```
 
-## Usage
+## Usage 
 
-1. Import the dependencies.
-
+1. Importing session-keys:
 ```rust
-use session_keys::{SessionError, SessionToken, session_auth_or, Session};
+   use session_keys::{SessionError, SessionToken, session_auth_or, Session};
 ```
+This line imports the necessary components from the session-keys crate.
 
-2. Derive the `Session` trait on your instruction struct.
+2. Deriving the Session trait:
+```rust
+   #[derive(Accounts, Session)]
+   pub struct Increment<'info> {
+     #[account(
+        mut, 
+        seeds = [ COUNTER_SEED, counter.authority.key().as_ref() ], 
+        bump
+     )]
+     pub counter: Account<'info, Counter>,
+     ...
+   }
+```
+The `Session` trait is derived on the `Increment` struct, enabling session functionality.
+
+3. Defining the session token account:
+```rust
+   #[session(
+       signer = signer,
+       authority = counter.authority.key() 
+   )]
+   pub session_token: Option<Account<'info, SessionToken>>,
+```
+This defines an optional `SessionToken` account, specifying the signer and authority for the session.
+- session_token.authority: account which created the session token
+- counter.authority.key(): account which created the counter
+The authority condition checks if the session token is created by the same user as the counter.
+
+4. Using the `session_auth_or` macro:
+```rust
+   #[session_auth_or(
+       ctx.accounts.counter.authority.key() == ctx.accounts.signer.key(),
+       SessionError::InvalidToken
+   )]
+   pub fn increment(ctx: Context<Increment>) -> Result<()> {
+       ...
+   }
+```
+This macro is applied to the `increment` function. 
+It checks for a valid session token, or if not present, verifies that the signer is the counter's authority.
+
+## Full Example
+
+Here's a complete example of a counter program using session keys.
+Each user gets his own counter account, so we can show how authentication is done with session keys.
 
 ```rust
-#[derive(Accounts, Session)]
-pub struct Instruction<'info> {
-    .....
-    pub user: Account<'info, User>,
+use anchor_lang::prelude::*;
+use session_keys::{SessionError, SessionToken, session_auth_or, Session};
 
-    #[session(
-        // The ephemeral keypair signing the transaction
-        signer = signer,
-        // The authority of the user account which must have created the session
-        authority = user.authority.key()
+declare_id!("...");
+const COUNTER_SEED: &[u8] = b"counter";
+
+#[program]
+pub mod counter_session {
+    use super::*;
+
+    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
+        let counter: &mut Counter = &mut ctx.accounts.counter;
+        counter.count = 0;
+        counter.authority = *ctx.accounts.owner.key;
+        Ok(())
+    }
+
+    #[session_auth_or(
+        ctx.accounts.counter.authority.key() == ctx.accounts.signer.key(),
+        SessionError::InvalidToken
     )]
-    // Session Tokens are passed as optional accounts
-    pub session_token: Option<Account<'info, SessionToken>>,
+    pub fn increment(ctx: Context<Increment>) -> Result<()> {
+        let counter: &mut Counter = &mut ctx.accounts.counter;
+        counter.count += 1;
+        Ok(())
+    }
+}
 
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(
+        init, 
+        payer = owner, 
+        space = Counter::INIT_SPACE + 8 , 
+        seeds = [ COUNTER_SEED, owner.key().as_ref() ], bump
+    )]
+    pub counter: Account<'info, Counter>,
+    #[account(mut)]
+    pub owner: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts, Session)]
+pub struct Increment<'info> {
+    #[account(
+        mut, 
+        seeds = [ COUNTER_SEED, counter.authority.key().as_ref() ], 
+        bump
+    )]
+    pub counter: Account<'info, Counter>,    
+    #[session(
+        signer = signer,
+        authority = counter.authority.key() 
+    )]
+    pub session_token: Option<Account<'info, SessionToken>>,
     #[account(mut)]
     pub signer: Signer<'info>,
-    .....
+}
+
+#[account]
+#[derive(InitSpace)]
+pub struct Counter {
+    pub authority: Pubkey,
+    pub count: u64,
 }
 ```
 
-3. Add the `session_auth_or` macro to your instruction handler with fallback logic on who the instruction should validate the signer when sessions are not present and an appropriate ErrorCode.\
-   \
-   If you've used `require*!` macros in anchor_lang, you already know how this works.
+## Tests
 
-```rust
-#[session_auth_or(
-    ctx.accounts.user.authority.key() == ctx.accounts.authority.key(),
-    ErrorCode
-)]
-pub fn ix_handler(ctx: Context<Instruction>,) -> Result<()> {
-.....
-}
+Here's an example of how to test the counter program with session keys:
+
+```typescript
+import * as anchor from "@project-serum/anchor";
+import { Program } from "@project-serum/anchor";
+import { CounterSession } from "../target/types/counter_session";
+import { createSessionToken } from "@session-keys/anchor";
+import { expect } from "chai";
+
+describe("counter_session", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace.CounterSession as Program<CounterSession>;
+
+  let counterPDA: anchor.web3.PublicKey;
+  let sessionToken: anchor.web3.PublicKey;
+
+  it("Initializes the counter", async () => {
+    const [pda] = await anchor.web3.PublicKey.findProgramAddress(
+      [Buffer.from("counter"), provider.wallet.publicKey.toBuffer()],
+      program.programId
+    );
+    counterPDA = pda;
+
+    await program.methods
+      .initialize()
+      .accounts({
+        counter: counterPDA,
+        owner: provider.wallet.publicKey,
+        systemProgram: anchor.web3.SystemProgram.programId,
+      })
+      .rpc();
+
+    const counterAccount = await program.account.counter.fetch(counterPDA);
+    expect(counterAccount.count).to.equal(0);
+    expect(counterAccount.authority.toString()).to.equal(provider.wallet.publicKey.toString());
+  });
+
+  it("Increments the counter without session", async () => {
+    await program.methods
+      .increment()
+      .accounts({
+        counter: counterPDA,
+        signer: provider.wallet.publicKey,
+      })
+      .rpc();
+
+    const counterAccount = await program.account.counter.fetch(counterPDA);
+    expect(counterAccount.count).to.equal(1);
+  });
+
+  it("Increments the counter with session token", async () => {
+    await program.methods
+      .increment()
+      .accounts({
+        counter: counterPDA,
+        sessionToken: sessionToken,
+        signer: provider.wallet.publicKey,
+      })
+      .rpc();
+
+    const counterAccount = await program.account.counter.fetch(counterPDA);
+    expect(counterAccount.count).to.equal(2);
+  });
+
+  it("fails to increment with wrong session token owner", async () => {
+    const user = anchor.web3.Keypair.generate();
+    await topUp(user);
+  
+    let counterPDA = await createCounterPDA(user.publicKey);    
+    await createCounter(user);
+
+    const secondUser = anchor.web3.Keypair.generate();
+    await topUp(secondUser);
+    const { sessionSigner, sessionToken } = await createSessionSigner(secondUser);    
+    
+    try {
+      await increment_with_session(counterPDA, sessionSigner, sessionToken);
+      assert(false, "Expected to fail");
+    } catch (err) {}
+
+    const counterData = await program.account.counter.fetch(counterPDA);
+    assert(counterData.count.eq(new anchor.BN(0)));
+  });
+});
+```
+
+This test suite demonstrates initializing the counter, incrementing it without a session, creating a session token, and then incrementing with the session token.
+The last test is important, as it ensures that only the owner of the counter can increment it.
+
+## Testing locally
+
+To test it locally with `solana-test-validator`, you need to start it with the session keys program and account. 
+
+1. Make sure your Solana CLI points to DEVNET:
+```
+solana config set --url https://api.devnet.solana.com
+```
+
+2. Dump Session Keys program to local file:
+```
+solana program dump KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5 ./session-keys.so
+```
+
+3. Start solana-test-validator with session keys program and account:
+> `-r` - reset the ledger to genesis 
+> `-ud` - URL for Solana's JSON RPC or moniker (-ud = DEVNET)
+> `--clone` - Copy an account from the cluster 
+> `--bpf-program` - add a SBF program to the genesis configuration
+```
+solana-test-validator -ud --clone KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5 -r --bpf-program KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5 ./session-keys.so
 ```


### PR DESCRIPTION
Motivation:
Existing docs on Session Keys integration aren't clear on what User.authority is and its importance when blocking unauthorized access to accounts via session tokens

This commit:
1. Gives full example of a Counter program 
2. Includes tests demonstrating access without sessionToken, as well as with correct and invalid tokens.
3. Instructs on how to run local solana validator with session keys program 

Comment:
My first attempt, more then open to any criticism.
IMO everything from `Full Example` should be moved to some examples part of this repo, so people can clone and mess with it locally.

cc @GabrielePicco 