### PR TITLE
Add randomness docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -131,7 +131,21 @@
                 ]
               }
             ]
-          }
+          },
+            {
+              "group": "Randomness",
+              "pages": [
+                {
+                  "group": "Verifiable Randomness",
+                  "pages": [
+                    "pages/tools/randomness/what-is-verifiable-randomness",
+                    "pages/tools/randomness/technical-details",
+                    "pages/tools/randomness/security",
+                    "pages/tools/randomness/implementation-example"
+                  ]
+                }
+              ]
+            }
         ]
       }
     ],

--- a/pages/tools/introduction.mdx
+++ b/pages/tools/introduction.mdx
@@ -41,4 +41,12 @@ description: "Utilize existing SDKs and Frameworks to accelerate your developmen
   >
     Integrate with Session Keys
   </Card>
+    <Card
+      title="Randomness"
+      icon="dice"
+      href="/pages/tools/randomness/what-is-verifiable-randomness"
+      iconType="duotone"
+    >
+      Verifiable randomness for games and apps
+    </Card>
 </CardGroup>

--- a/pages/tools/randomness/implementation-example.mdx
+++ b/pages/tools/randomness/implementation-example.mdx
@@ -1,0 +1,27 @@
+---
+title: "Implementation Example"
+description: "Using randomness in a rollup program"
+---
+
+Below is a simplified example showing how a rollup program requests and consumes randomness.
+
+```rust
+use ephemeral_vrf_sdk::{create_request_randomness_ix, random_u8_with_range};
+
+pub fn request_loot_drop(ctx: Context<RequestLootDrop>, seed: [u8; 32]) -> Result<()> {
+    create_request_randomness_ix(ctx.accounts.vrf_program_identity.key(), seed, consume_randomness)?;
+    Ok(())
+}
+
+pub fn consume_randomness(ctx: Context<ConsumeRandomness>, value: [u8; 32]) -> Result<()> {
+    let roll = random_u8_with_range(&value, 0..100);
+    if roll < 50 {
+        // grant rare loot
+    }
+    Ok(())
+}
+```
+
+The first instruction requests randomness and specifies the callback `consume_randomness`. Once the VRF proof is generated, the runtime calls the callback, passing the random output for use in game logic.
+This pattern runs entirely within the [ephemeral rollup](/pages/get-started/introduction/ephemeral-rollup) environment.
+

--- a/pages/tools/randomness/security.mdx
+++ b/pages/tools/randomness/security.mdx
@@ -1,0 +1,17 @@
+---
+title: "Security"
+description: "How randomness proofs are verified"
+---
+
+The randomness proof is cryptographically bound to the input `caller_seed` and to MagicBlock's VRF signer identity. Your callback enforces this with:
+
+```rust
+#[account(address = ephemeral_vrf_sdk::consts::VRF_PROGRAM_IDENTITY)]
+pub vrf_program_identity: Signer<'info>,
+```
+
+Only the official MagicBlock oracle can trigger the callback, preventing spoofed or manipulated results. Invalid proofs automatically fail, and other programs cannot front‑run the request.
+
+Avoid letting users provide the entire `caller_seed` directly—combine it with game state or timestamps to prevent seed grinding. Because everything executes inside the deterministic rollup, the random value cannot be reused or delayed.
+This enforcement happens within the same [ephemeral rollup](/pages/get-started/introduction/ephemeral-rollup) that executes your game logic.
+

--- a/pages/tools/randomness/technical-details.mdx
+++ b/pages/tools/randomness/technical-details.mdx
@@ -1,0 +1,12 @@
+---
+title: "Technical Details"
+description: "How MagicBlock integrates verifiable randomness"
+---
+See the [Ephemeral Rollup documentation](/pages/get-started/introduction/ephemeral-rollup) for an overview of the runtime.
+
+MagicBlock exposes randomness as a first-class primitive through the `ephemeral_vrf_sdk`. Rollup programs call `create_request_randomness_ix`, providing a `caller_seed` and a callback, such as `consume_randomness`.
+
+Random numbers are generated via a VRF built on Curve25519 and proven using Schnorr-style signatures. The proof and output are returned to the rollup with a signed callback from the MagicBlock VRF signer PDA. Your program verifies the caller and then uses the randomness in gameplay logic.
+
+Helper utilities like `random_u32`, `random_u8_with_range`, and `random_bool` make it simple to convert the `[u8; 32]` output into usable values. Because the request and consume steps occur inside the ephemeral execution window, users get real-time results with verifiable fairness and without relying on external servers.
+

--- a/pages/tools/randomness/what-is-verifiable-randomness.mdx
+++ b/pages/tools/randomness/what-is-verifiable-randomness.mdx
@@ -1,0 +1,18 @@
+---
+title: "What is Verifiable Randomness?"
+description: "Provably fair randomness for on-chain logic"
+---
+
+Verifiable randomness provides a tamper-proof source of chance for on-chain programs. 
+Unlike pseudorandom values derived from timestamps or block hashes, it is generated off-chain and delivered alongside a cryptographic proof that anyone can verify on-chain.
+
+This lets programs implement mechanics like loot drops, gacha pulls, or matchmaking without trusting a single party. The receipt proves that the number was produced fairly and cannot be manipulated.
+
+#### Example use cases
+
+- Provably fair loot boxes or chest drops
+- Secure gacha systems
+- Randomized spawn or resource generation
+- Chain-verified PvP matchmaking
+- Trustless raffles or giveaways
+


### PR DESCRIPTION
## Summary
- add Randomness group in docs navigation
- document verifiable randomness with examples
- link randomness from Tools intro

## Testing
- `jq '.' docs.json`
- `npx markdownlint pages/tools/randomness/*.mdx` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684815438a6083298fcb7d27a63bf59a